### PR TITLE
Add PHP network monitoring program

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# PHP Network Device Monitor
+
+This simple project provides a basic visual network monitoring tool implemented in PHP. It checks the connectivity of devices by pinging them every five minutes using multiple processes.
+
+## Files
+
+- `devices.json` – list of devices to monitor (`floor`, `ip`, `location`).
+- `monitor.php` – CLI script that performs the ping tests in parallel using `pcntl_fork` and writes the latest results to `results.json`.
+- `index.php` – web page that displays the last monitoring result.
+- `results.json` – automatically generated file holding the last ping results.
+
+## Usage
+
+1. Update `devices.json` with your network devices.
+2. Run the monitor script in the background:
+   ```bash
+   php monitor.php &
+   ```
+   It will ping each device every 5 minutes sending 3 packets.
+3. Serve `index.php` through a web server such as Apache or PHP's built‑in server:
+   ```bash
+   php -S localhost:8000
+   ```
+4. Visit `http://localhost:8000/index.php` to see the status page. Green indicator means the device responded to ping; red indicates failure.

--- a/devices.json
+++ b/devices.json
@@ -1,0 +1,4 @@
+[
+  {"floor": "1F", "ip": "192.168.1.10", "location": "Server Room"},
+  {"floor": "2F", "ip": "192.168.1.20", "location": "Office"}
+]

--- a/index.php
+++ b/index.php
@@ -14,30 +14,68 @@ foreach ($devices as $dev) {
 <meta charset="UTF-8">
 <title>Network Monitor</title>
 <style>
-body { font-family: Arial, sans-serif; }
-.floor { margin-bottom: 20px; }
-.status { display: inline-block; width: 12px; height: 12px; border-radius: 50%; }
-.status.up { background: #0f0; }
-.status.down { background: #f00; }
+body {
+  font-family: Arial, sans-serif;
+  background: #f4f4f4;
+  margin: 0;
+  padding: 20px;
+}
+h1 {
+  text-align: center;
+}
+.floor {
+  margin-bottom: 30px;
+}
+.floor-title {
+  font-size: 1.2em;
+  margin-bottom: 10px;
+}
+.device-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 10px;
+}
+.device-card {
+  background: #fff;
+  border-radius: 4px;
+  padding: 10px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  display: flex;
+  align-items: center;
+}
+.status {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  margin-right: 8px;
+}
+.status.up { background: #4caf50; }
+.status.down { background: #f44336; }
 .status.unknown { background: #ccc; }
+.device-info {
+  display: flex;
+  flex-direction: column;
+}
 </style>
 </head>
 <body>
 <h1>Network Device Status</h1>
-<p>Last updated: <?php echo htmlspecialchars($timestamp); ?></p>
+<p style="text-align:center;">Last updated: <?= htmlspecialchars($timestamp) ?></p>
 <?php foreach ($byFloor as $floor => $list): ?>
 <div class="floor">
-  <h2>Floor <?php echo htmlspecialchars($floor); ?></h2>
-  <table border="1" cellpadding="5" cellspacing="0">
-    <tr><th>IP</th><th>Location</th><th>Status</th></tr>
+  <div class="floor-title">Floor <?= htmlspecialchars($floor) ?></div>
+  <div class="device-grid">
     <?php foreach ($list as $device): ?>
-    <tr>
-      <td><?php echo htmlspecialchars($device['ip']); ?></td>
-      <td><?php echo htmlspecialchars($device['location']); ?></td>
-      <td><span class="status <?php echo htmlspecialchars($device['status']); ?>"></span> <?php echo htmlspecialchars($device['status']); ?></td>
-    </tr>
+    <div class="device-card">
+      <span class="status <?= htmlspecialchars($device['status']) ?>"></span>
+      <div class="device-info">
+        <div><?= htmlspecialchars($device['ip']) ?></div>
+        <div><?= htmlspecialchars($device['location']) ?></div>
+      </div>
+    </div>
     <?php endforeach; ?>
-  </table>
+  </div>
 </div>
 <?php endforeach; ?>
 </body>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,44 @@
+<?php
+$resultFile = __DIR__ . '/results.json';
+$data = json_decode(file_get_contents($resultFile), true);
+$timestamp = $data['timestamp'] ?? '';
+$devices = $data['devices'] ?? [];
+$byFloor = [];
+foreach ($devices as $dev) {
+    $byFloor[$dev['floor']][] = $dev;
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Network Monitor</title>
+<style>
+body { font-family: Arial, sans-serif; }
+.floor { margin-bottom: 20px; }
+.status { display: inline-block; width: 12px; height: 12px; border-radius: 50%; }
+.status.up { background: #0f0; }
+.status.down { background: #f00; }
+.status.unknown { background: #ccc; }
+</style>
+</head>
+<body>
+<h1>Network Device Status</h1>
+<p>Last updated: <?php echo htmlspecialchars($timestamp); ?></p>
+<?php foreach ($byFloor as $floor => $list): ?>
+<div class="floor">
+  <h2>Floor <?php echo htmlspecialchars($floor); ?></h2>
+  <table border="1" cellpadding="5" cellspacing="0">
+    <tr><th>IP</th><th>Location</th><th>Status</th></tr>
+    <?php foreach ($list as $device): ?>
+    <tr>
+      <td><?php echo htmlspecialchars($device['ip']); ?></td>
+      <td><?php echo htmlspecialchars($device['location']); ?></td>
+      <td><span class="status <?php echo htmlspecialchars($device['status']); ?>"></span> <?php echo htmlspecialchars($device['status']); ?></td>
+    </tr>
+    <?php endforeach; ?>
+  </table>
+</div>
+<?php endforeach; ?>
+</body>
+</html>

--- a/monitor.php
+++ b/monitor.php
@@ -1,0 +1,61 @@
+<?php
+// Network device monitor script
+set_time_limit(0);
+
+$deviceFile = __DIR__ . '/devices.json';
+$resultFile = __DIR__ . '/results.json';
+
+if (!function_exists('pcntl_fork')) {
+    fwrite(STDERR, "pcntl extension is required\n");
+    exit(1);
+}
+
+function pingDevice($ip) {
+    $cmd = sprintf('ping -c 3 %s 2>&1', escapeshellarg($ip));
+    exec($cmd, $output, $ret);
+    return $ret === 0; // 0 means success
+}
+
+while (true) {
+    $devices = json_decode(file_get_contents($deviceFile), true);
+    $children = [];
+    $tempDir = sys_get_temp_dir();
+
+    foreach ($devices as $index => $device) {
+        $pid = pcntl_fork();
+        if ($pid == -1) {
+            continue; // fork failed
+        } elseif ($pid) {
+            $children[$pid] = $index;
+        } else {
+            $status = pingDevice($device['ip']) ? 'up' : 'down';
+            $tmp = "$tempDir/monitor_{$index}.json";
+            file_put_contents($tmp, json_encode(['index' => $index, 'status' => $status]));
+            exit(0);
+        }
+    }
+
+    foreach ($children as $pid => $index) {
+        pcntl_waitpid($pid, $status);
+    }
+
+    $results = [
+        'timestamp' => date('c'),
+        'devices' => []
+    ];
+
+    foreach ($devices as $index => $device) {
+        $tmp = "$tempDir/monitor_{$index}.json";
+        if (file_exists($tmp)) {
+            $data = json_decode(file_get_contents($tmp), true);
+            unlink($tmp);
+            $device['status'] = $data['status'];
+        } else {
+            $device['status'] = 'unknown';
+        }
+        $results['devices'][] = $device;
+    }
+
+    file_put_contents($resultFile, json_encode($results, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+    sleep(300); // wait 5 minutes
+}

--- a/results.json
+++ b/results.json
@@ -1,0 +1,1 @@
+{"timestamp":"","devices":[]}


### PR DESCRIPTION
## Summary
- implement `monitor.php` to ping devices every five minutes using child processes
- add `index.php` to visualize results with green and red indicators
- include sample `devices.json` and `results.json`
- document how to use the monitor in `README.md`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525a5b1874832fa68cd53d44405f04