### PR TITLE
[Follow-up] Fix container resolution for zero-argument service closures

### DIFF
--- a/backend/src/Application.php
+++ b/backend/src/Application.php
@@ -46,7 +46,11 @@ class Application
 
         $value = $this->bindings[$key];
         if ($value instanceof \Closure) {
-            $value = $value($this);
+            $reflection = new \ReflectionFunction($value);
+
+            $value = $reflection->getNumberOfParameters() > 0
+                ? $value($this)
+                : $value();
         }
 
         $this->instances[$key] = $value;


### PR DESCRIPTION
### Motivation
- Prevent `ArgumentCountError` when resolving services registered with zero-argument closures, since the router bootstrap registers `function (): Router { ... }` and should be invoked with no arguments. 

### Description
- Update `Application::get()` to inspect closure arity using `	ReflectionFunction` and invoke service factories with no arguments when they declare zero parameters. 
- Continue passing the container instance to closures that opt in by declaring one or more parameters. 
- Change implemented in `backend/src/Application.php` (closure invocation branch).

### Testing
- Ran syntax checks with `php -l backend/src/Application.php` and `php -l backend/tests/ApplicationTest.php`, both succeeded. 
- Attempted to run tests via `cd backend && vendor/bin/phpunit --filter ApplicationTest` but `phpunit` is not installed in the environment so the test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a27c2ec564832fad456d82d3c4fc48)